### PR TITLE
Avoid NullPointerException on opType equals

### DIFF
--- a/spring-sync-core/src/main/java/org/springframework/sync/json/JsonPatchPatchConverter.java
+++ b/spring-sync-core/src/main/java/org/springframework/sync/json/JsonPatchPatchConverter.java
@@ -66,17 +66,17 @@ public class JsonPatchPatchConverter implements PatchConverter<JsonNode> {
 			Object value = valueFromJsonNode(path, valueNode);			
 			String from = opNode.has("from") ? opNode.get("from").textValue() : null;
 
-			if (opType.equals("test")) {
+			if ("test".equals(opType)) {
 				ops.add(new TestOperation(path, value));
-			} else if (opType.equals("replace")) {
+			} else if ("replace".equals(opType)) {
 				ops.add(new ReplaceOperation(path, value));
-			} else if (opType.equals("remove")) {
+			} else if ("remove".equals(opType)) {
 				ops.add(new RemoveOperation(path));
-			} else if (opType.equals("add")) {
+			} else if ("add".equals(opType)) {
 				ops.add(new AddOperation(path, value));
-			} else if (opType.equals("copy")) {
+			} else if ("copy".equals(opType)) {
 				ops.add(new CopyOperation(path, from));
-			} else if (opType.equals("move")) {
+			} else if ("move".equals(opType)) {
 				ops.add(new MoveOperation(path, from));
 			} else {
 				throw new PatchException("Unrecognized operation type: " + opType);


### PR DESCRIPTION
Put the equals on String to avoid NullPointerException and to get the PatchException message that explains a little better the issue.